### PR TITLE
Fix potential overwrite of pass-code store

### DIFF
--- a/code.bash
+++ b/code.bash
@@ -22,10 +22,15 @@ codec_modified=false
 # Decrypt the .passcode file and put it to an associative array so we
 # don't need to re-decrpyt it every time we encode/decode something.
 code_decrypt() {
-	while read -r pair; do
-		codec["Dx${pair##*:}"]="${pair%%:*}"
-		codec["Ex${pair%%:*}"]="${pair##*:}"
-	done <<< "$(cmd_show .passcode 2>/dev/null)"
+	local passcode
+	if passcode="$(cmd_show .passcode 2>/dev/null)" ; then
+		while read -r pair; do
+			codec["Dx${pair##*:}"]="${pair%%:*}"
+			codec["Ex${pair%%:*}"]="${pair##*:}"
+		done <<< "$passcode"
+	else
+		die "Could not decrypt pass-code store"
+	fi
 }
 
 # Will not print anything if code_decrypt not run or key not in mapping


### PR DESCRIPTION
Previously, if `cmd_show` fails, e.g. because gpg fails, pass-code continues with
an empty `codec`. This is not a problem when doing an `ls` but an
`insert` will overwrite the `.passcode` file with just the newly inserted
item.

This fix checks for the success of `cmd_show` and aborts on failure.